### PR TITLE
Removes status code as an indicator of successful authentication

### DIFF
--- a/CVE-2024-46987.py
+++ b/CVE-2024-46987.py
@@ -42,7 +42,7 @@ class CamaleonLFI:
         }
         
         r = self.session.post(login_url, data=data, allow_redirects=True)
-        success = 'logout' in r.text.lower() or r.status_code == 200
+        success = 'logout' in r.text.lower()
         
         if success:
             self.log("Authentification réussie.")


### PR DESCRIPTION
A status code of 200 is received regardless of successful or unsuccessful authentication. Tested on Camaleon 2.9.0